### PR TITLE
bug: 버튼 컴포넌트 내 cn유틸함수 충돌해결

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -39,13 +39,7 @@ const Button = ({
   return (
     <button
       type={type}
-      className={cn(
-        "btn inline-flex justify-center items-center",
-        sizeClass,
-        styleClass,
-        focusShadowClass,
-        className
-      )}
+      className={`btn inline-flex justify-center items-center ${sizeClass} ${styleClass} ${focusShadowClass} ${className}`}
       {...props}
     >
       {children}

--- a/src/components/Button/buttonStyles.js
+++ b/src/components/Button/buttonStyles.js
@@ -1,8 +1,8 @@
 export const BTN_SIZES = {
-  "btn-28": "py-0.5 px-4 text-14 font-normal rounded-md",
-  "btn-36": "py-1.5 px-4 text-16 font-medium rounded-md",
-  "btn-40": "py-2 px-4 text-16 font-normal rounded-md",
-  "btn-56": "py-3.5 px-4 text-18 font-bold rounded-xl",
+  "btn-28": "h-7 px-4 text-14 font-normal rounded-md",
+  "btn-36": "h-9 px-4 text-16 font-medium rounded-md",
+  "btn-40": "h-10 px-4 text-16 font-normal rounded-md",
+  "btn-56": "h-14 px-4 text-18 font-bold rounded-xl",
   "btn-icon-32": "w-8 h-8 rounded-md relative",
   "btn-icon-36": "w-9 h-9 rounded-md relative",
   "btn-icon-40": "w-10 h-10 rounded-full relative",

--- a/src/components/Icon/icon.css
+++ b/src/components/Icon/icon.css
@@ -7,7 +7,6 @@
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-position: center;
   -webkit-mask-size: contain;
-  background-color: #181818;
 }
 .btn-icon {
   position: absolute;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -56,8 +56,8 @@ export default {
       },
       fontSize: {
         12: ["0.75rem", { lineHeight: "1.5", letterSpacing: "-0.005em" }], // -0.5%
-        14: ["0.875rem", { lineHeight: "1.4", letterSpacing: "-0.005em" }],
-        15: ["0.9375rem", { lineHeight: "1.4", letterSpacing: "-0.01em" }], // -1%
+        14: ["0.875rem", { lineHeight: "1.43", letterSpacing: "-0.005em" }],
+        15: ["0.9375rem", { lineHeight: "1.43", letterSpacing: "-0.01em" }], // -1%
         16: ["1rem", { lineHeight: "1.6", letterSpacing: "-0.01em" }],
         18: ["1.125rem", { lineHeight: "1.5", letterSpacing: "-0.01em" }],
         20: ["1.25rem", { lineHeight: "1.5", letterSpacing: "-0.01em" }],


### PR DESCRIPTION
## 변경 사항 요약

<버그 내용>
기존 버튼 컴포넌트에서 폰트가 무시되는 버그 발생 
버튼 컴포넌트 내에서 text-14 -> text-purple-600 순서로 작성 시 text-14 무시, 
text-purple-600 -> text-14 순서로 작성시 text-purple-600가 무시되는 현상 발생. 
단.   p className="text-14 text-purple-600" 형태는 작성가능.

지권님과 함께 트러블 슈팅 결과 
1. !text-20 text-purple-800 으로 변경 시 해결
2. cn 유틸함수 제거 후 해결

= cn 유틸 함수 동작때문에 발생하는 문제로 내부에서 "text-"를 같은 속성으로 인식 후 필터링 로직 의심

<해결방안> 
1. cn 을 제거하는 방식 ---  선택
2. BTN_STYLES 에서 색상, 폰트를 빼는 방법 (비추천)
3. ! 사용해서 테일윈드 강제 부여

<버그 수정 외 컴포넌트 수정사항>
1. 폰트적용에 맞추어 컴포넌트 크기를 조정 했습니다 
padding 방식 -> height 부여 
2. icon.css 기본으로 선언된 컬러 제거
컴포넌트 유연함을 높이고, 버튼처럼 여러속성이 있을 경우 적용이 안될 경우 대비

### 추가된 기능

- [x] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [ ] UI 변경
- [ ] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항

추후 컴포넌트를 만들때 동일한 이슈가 발생시 해당 디스크립션을 참고해주세요 
<img width="487" height="315" alt="스크린샷 2025-08-12 오후 5 52 39" src="https://github.com/user-attachments/assets/61001a42-25f0-4d44-969b-a181e8743d71" />


### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인
