### PR TITLE
이모지 드롭다운 컴포넌트 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,12 +17,8 @@ function App() {
         >
           4팀 화이팅 &#x1F60A;
         </h1>
-        <div className="flex">
-          {REACTIONS_DATA.results.map((result) => {
-            return <BadgeEmoji key={result.id} reactions={result} />;
-          })}
-        </div>
 
+        {/* Emoji Dropdown component */}
         <DropdownEmoji reactionData={REACTIONS_DATA} />
 
         {/* Input Components */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Card from "./components/Card/Card";
 import AddCard from "./components/Card/AddCard";
 import { CardMockData, REACTIONS_DATA } from "./MockData";
 import BadgeEmoji from "./components/Badge/BadgeEmoji";
+import DropdownEmoji from "./components/Dropdown/DropdownEmoji";
 
 function App() {
   return (
@@ -21,6 +22,8 @@ function App() {
             return <BadgeEmoji key={result.id} reactions={result} />;
           })}
         </div>
+
+        <DropdownEmoji reactionData={REACTIONS_DATA} />
 
         {/* Card Components */}
         <div className="grid grid-cols-3 grid-row-2 gap-[24px]">

--- a/src/MockData.js
+++ b/src/MockData.js
@@ -66,5 +66,35 @@ export const REACTIONS_DATA = {
       emoji: "😘",
       count: 1,
     },
+    {
+      id: 13352,
+      emoji: "😌",
+      count: 1,
+    },
+    {
+      id: 13353,
+      emoji: "😝",
+      count: 1,
+    },
+    {
+      id: 13354,
+      emoji: "😘",
+      count: 1,
+    },
+    {
+      id: 13355,
+      emoji: "😌",
+      count: 1,
+    },
+    {
+      id: 13356,
+      emoji: "😝",
+      count: 1,
+    },
+    {
+      id: 13357,
+      emoji: "😘",
+      count: 1,
+    },
   ],
 };

--- a/src/MockData.js
+++ b/src/MockData.js
@@ -37,7 +37,7 @@ export const CardMockData = [
 ];
 
 export const REACTIONS_DATA = {
-  count: 5,
+  count: 11,
   next: null,
   previous: null,
   results: [

--- a/src/components/Badge/BadgeEmoji.jsx
+++ b/src/components/Badge/BadgeEmoji.jsx
@@ -14,7 +14,7 @@ const EmojiBadge = ({ reactions }) => {
         className={cn(
           "h-[36px] bg-black/60 rounded-[32px]",
           "flex justify-center items-center gap-x-0.5",
-          "p-3.5"
+          "px-3.5"
         )}
       >
         <div className={cn("text-base")}>{emoji}</div>

--- a/src/components/Badge/BadgeEmoji.jsx
+++ b/src/components/Badge/BadgeEmoji.jsx
@@ -5,16 +5,18 @@ import { cn } from "../../utils";
  * @author <hwitae>
  * @param {Object{}} reactions emoji와 count가 들어있는 객체
  */
-const EmojiBadge = ({ reactions = {} }) => {
+const EmojiBadge = ({ reactions = {}, style = "" }) => {
   const { emoji, count } = reactions;
 
   return (
     <>
       <div
         className={cn(
-          "h-[36px] bg-black/60 rounded-[32px]",
-          "flex justify-center items-center gap-x-0.5",
-          "px-[13px] text-base leading-[26px] tracking-[-0.01em] m-0 font-normal"
+          "desktop:w-fit desktop:h-[38px]",
+          "bg-black/60 rounded-[32px] flex justify-center items-center gap-x-0.5",
+          "px-[13px] leading-[26px] tracking-[-0.01em] m-0",
+          "tablet:text-base mobile:text-14 font-normal",
+          style
         )}
       >
         <p>{emoji}</p>

--- a/src/components/Badge/BadgeEmoji.jsx
+++ b/src/components/Badge/BadgeEmoji.jsx
@@ -5,7 +5,7 @@ import { cn } from "../../utils";
  * @author <hwitae>
  * @param {Object{}} reactions emoji와 count가 들어있는 객체
  */
-const EmojiBadge = ({ reactions }) => {
+const EmojiBadge = ({ reactions = {} }) => {
   const { emoji, count } = reactions;
 
   return (
@@ -14,11 +14,11 @@ const EmojiBadge = ({ reactions }) => {
         className={cn(
           "h-[36px] bg-black/60 rounded-[32px]",
           "flex justify-center items-center gap-x-0.5",
-          "px-3.5"
+          "px-[13px] text-base leading-[26px] tracking-[-0.01em] m-0 font-normal"
         )}
       >
-        <div className={cn("text-base")}>{emoji}</div>
-        <p className={cn("text-white text-base m-0")}>{count}</p>
+        <p>{emoji}</p>
+        <p className={cn("text-white")}>{count}</p>
       </div>
     </>
   );

--- a/src/components/Dropdown/DropdownElement/DropdownButton.jsx
+++ b/src/components/Dropdown/DropdownElement/DropdownButton.jsx
@@ -1,0 +1,17 @@
+import { memo } from "react";
+import { cn } from "../../../utils";
+import Icon from "../../Icon/Icon";
+
+const DropdownButton = ({ onClickOpen, isOpen }) => {
+  return (
+    <div className={"flex items-center w-[36px]"} onClick={onClickOpen}>
+      <Icon
+        iconName="arrow_down"
+        iconSize="ic-24"
+        className={cn("bg-black cursor-pointer", isOpen && "rotate-180")}
+      />
+    </div>
+  );
+};
+
+export default memo(DropdownButton);

--- a/src/components/Dropdown/DropdownElement/DropdownExpandEmoji.jsx
+++ b/src/components/Dropdown/DropdownElement/DropdownExpandEmoji.jsx
@@ -1,0 +1,35 @@
+import { memo } from "react";
+import { cn } from "../../../utils";
+import BadgeEmoji from "../../Badge/BadgeEmoji";
+
+const DropdownExpandEmoji = ({ reactionList }) => {
+  return (
+    <div className={"absolute tablet:top-12 mobile:top-9 right-px"}>
+      <div
+        className={cn(
+          "desktop:w-[312px] bg-white",
+          "tablet:w-[248px] tablet:p-[24px]",
+          "mobile:w-[203px] p-4",
+          "border border-gray-dropdownBorder rounded-lg",
+          "drop-shadow-dropdownBorder"
+        )}
+      >
+        <div className="flex flex-wrap gap-[10px]">
+          {reactionList.map((reaction) => {
+            return (
+              <BadgeEmoji
+                key={reaction.id}
+                reactions={reaction}
+                style={
+                  "tablet:w-fit tablet:h-[38px] mobile:w-[49px] mobile:h-[28px]"
+                }
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default memo(DropdownExpandEmoji);

--- a/src/components/Dropdown/DropdownEmoji.jsx
+++ b/src/components/Dropdown/DropdownEmoji.jsx
@@ -57,7 +57,7 @@ const DropdownEmoji = ({ reactionData = {}, dropdown = true }) => {
             <Icon
               iconName="arrow_down"
               iconSize="ic-24"
-              className={cn("bg-black cursor-pointer")}
+              className={cn("bg-black cursor-pointer", isOpen && "rotate-180")}
             />
           </div>
         )}

--- a/src/components/Dropdown/DropdownEmoji.jsx
+++ b/src/components/Dropdown/DropdownEmoji.jsx
@@ -1,0 +1,69 @@
+import { memo, useState } from "react";
+import { cn } from "../../utils";
+import BadgeEmoji from "../Badge/BadgeEmoji";
+import Icon from "../Icon/Icon";
+
+/**
+ * 이모지 리액션을 모아둔 드롭다운 리스트
+ * @author <hwitae>
+ * @param {Object{}} reactionData API로 받아온 reactions 데이터
+ */
+const DropdownEmoji = ({ reactionData }) => {
+  const { count, results } = reactionData;
+
+  /**
+   * 가장 많은 리액션을 받은 항목 최대 3개를 담는 배열
+   */
+  const preview = results.sort((a, b) => b.count - a.count).slice(0, 3);
+
+  /**
+   * 드롭다운 열림/닫힘 상태
+   */
+  const [isOpen, setIsOpen] = useState(true);
+
+  /**
+   * 버튼 클릭시 드롭다운 열림/닫힘 상태를 변경한다.
+   */
+  const onClickOpen = () => {
+    setIsOpen((prevState) => !prevState);
+  };
+
+  return (
+    <>
+      <div className={cn("flex gap-x-2 items-center relative")}>
+        <div className={cn("flex justify-end gap-x-2 w-[208px]")}>
+          {preview.map((reaction) => {
+            return <BadgeEmoji key={reaction.id} reactions={reaction} />;
+          })}
+        </div>
+        {count > 3 && (
+          <div className={cn("flex items-center")} onClick={onClickOpen}>
+            <Icon
+              iconName="arrow_down"
+              iconSize="ic-24"
+              className={cn("bg-black cursor-pointer")}
+            />
+          </div>
+        )}
+        {isOpen && (
+          <div className={cn("absolute top-12 right-px")}>
+            <div
+              className={cn(
+                "w-[312px] h-[134px] p-[24px] bg-white",
+                "border border-gray-dropdownBorder rounded-lg",
+                "drop-shadow-dropdownBorder"
+              )}
+            >
+              <div className={cn("flex flex-wrap gap-2.5")}>
+                {results.map((reaction) => {
+                  return <BadgeEmoji key={reaction.id} reactions={reaction} />;
+                })}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+export default memo(DropdownEmoji);

--- a/src/components/Dropdown/DropdownEmoji.jsx
+++ b/src/components/Dropdown/DropdownEmoji.jsx
@@ -3,6 +3,8 @@ import { cn } from "../../utils";
 import BadgeEmoji from "../Badge/BadgeEmoji";
 import Icon from "../Icon/Icon";
 import Button from "../Button/Button";
+import DropdownButton from "./DropdownElement/DropdownButton";
+import DropdownExpandEmoji from "./DropdownElement/DropdownExpandEmoji";
 
 /**
  * 이모지 리액션을 모아둔 드롭다운 리스트
@@ -50,44 +52,9 @@ const DropdownEmoji = ({ reactionData = {}, dropdown = true }) => {
           })}
         </div>
         {dropdown && count > 3 && (
-          <div
-            className={cn("flex items-center w-[36px]")}
-            onClick={onClickOpen}
-          >
-            <Icon
-              iconName="arrow_down"
-              iconSize="ic-24"
-              className={cn("bg-black cursor-pointer", isOpen && "rotate-180")}
-            />
-          </div>
+          <DropdownButton onClickOpen={onClickOpen} isOpen={isOpen} />
         )}
-        {isOpen && (
-          <div className={cn("absolute tablet:top-12 mobile:top-9 right-px")}>
-            <div
-              className={cn(
-                "desktop:w-[312px] bg-white",
-                "tablet:w-[248px] tablet:p-[24px]",
-                "mobile:w-[203px] p-4",
-                "border border-gray-dropdownBorder rounded-lg",
-                "drop-shadow-dropdownBorder"
-              )}
-            >
-              <div className={cn("flex flex-wrap gap-[10px]")}>
-                {results.map((reaction) => {
-                  return (
-                    <BadgeEmoji
-                      key={reaction.id}
-                      reactions={reaction}
-                      style={
-                        "tablet:w-fit tablet:h-[38px] mobile:w-[49px] mobile:h-[28px]"
-                      }
-                    />
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-        )}
+        {isOpen && <DropdownExpandEmoji reactionList={results} />}
       </div>
     </>
   );

--- a/src/components/Dropdown/DropdownEmoji.jsx
+++ b/src/components/Dropdown/DropdownEmoji.jsx
@@ -2,14 +2,15 @@ import { memo, useState } from "react";
 import { cn } from "../../utils";
 import BadgeEmoji from "../Badge/BadgeEmoji";
 import Icon from "../Icon/Icon";
+import Button from "../Button/Button";
 
 /**
  * 이모지 리액션을 모아둔 드롭다운 리스트
  * @author <hwitae>
  * @param {Object{}} reactionData API로 받아온 reactions 데이터
  */
-const DropdownEmoji = ({ reactionData }) => {
-  const { count, results } = reactionData;
+const DropdownEmoji = ({ reactionData = {}, dropdown = true }) => {
+  const { count = 0, results = [] } = reactionData;
 
   /**
    * 가장 많은 리액션을 받은 항목 최대 3개를 담는 배열
@@ -19,7 +20,7 @@ const DropdownEmoji = ({ reactionData }) => {
   /**
    * 드롭다운 열림/닫힘 상태
    */
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
 
   /**
    * 버튼 클릭시 드롭다운 열림/닫힘 상태를 변경한다.
@@ -31,12 +32,24 @@ const DropdownEmoji = ({ reactionData }) => {
   return (
     <>
       <div className={cn("flex items-center relative")}>
-        <div className={cn("flex justify-center gap-x-2 w-[208px]")}>
+        <div
+          className={cn(
+            "flex justify-center gap-x-2 tablet:w-[208px] mobile:w-[177px]"
+          )}
+        >
           {preview.map((reaction) => {
-            return <BadgeEmoji key={reaction.id} reactions={reaction} />;
+            return (
+              <BadgeEmoji
+                key={reaction.id}
+                reactions={reaction}
+                style={
+                  "tablet:w-fit tablet:h-[36px] mobile:w-[55px] mobile:h-[28px]"
+                }
+              />
+            );
           })}
         </div>
-        {count > 3 && (
+        {dropdown && count > 3 && (
           <div
             className={cn("flex items-center w-[36px]")}
             onClick={onClickOpen}
@@ -49,18 +62,27 @@ const DropdownEmoji = ({ reactionData }) => {
           </div>
         )}
         {isOpen && (
-          <div className={cn("absolute top-12 right-px")}>
+          <div className={cn("absolute tablet:top-12 mobile:top-9 right-px")}>
             <div
               className={cn(
-                "tablet:w-[312px] tablet:h-[134px] p-[24px] bg-white",
-                "mobile:w-[248px] h-[134px]",
+                "desktop:w-[312px] desktop:h-[134px] bg-white",
+                "tablet:w-[248px] tablet:h-[134px] tablet:p-[24px]",
+                "mobile:w-[203px] mobile:h-[98px] p-4",
                 "border border-gray-dropdownBorder rounded-lg",
                 "drop-shadow-dropdownBorder"
               )}
             >
-              <div className={cn("flex flex-wrap gap-2.5")}>
+              <div className={cn("flex flex-wrap gap-[10px]")}>
                 {results.map((reaction) => {
-                  return <BadgeEmoji key={reaction.id} reactions={reaction} />;
+                  return (
+                    <BadgeEmoji
+                      key={reaction.id}
+                      reactions={reaction}
+                      style={
+                        "tablet:w-fit tablet:h-[38px] mobile:w-[49px] mobile:h-[28px]"
+                      }
+                    />
+                  );
                 })}
               </div>
             </div>

--- a/src/components/Dropdown/DropdownEmoji.jsx
+++ b/src/components/Dropdown/DropdownEmoji.jsx
@@ -65,9 +65,9 @@ const DropdownEmoji = ({ reactionData = {}, dropdown = true }) => {
           <div className={cn("absolute tablet:top-12 mobile:top-9 right-px")}>
             <div
               className={cn(
-                "desktop:w-[312px] desktop:h-[134px] bg-white",
-                "tablet:w-[248px] tablet:h-[134px] tablet:p-[24px]",
-                "mobile:w-[203px] mobile:h-[98px] p-4",
+                "desktop:w-[312px] bg-white",
+                "tablet:w-[248px] tablet:p-[24px]",
+                "mobile:w-[203px] p-4",
                 "border border-gray-dropdownBorder rounded-lg",
                 "drop-shadow-dropdownBorder"
               )}

--- a/src/components/Dropdown/DropdownEmoji.jsx
+++ b/src/components/Dropdown/DropdownEmoji.jsx
@@ -30,14 +30,17 @@ const DropdownEmoji = ({ reactionData }) => {
 
   return (
     <>
-      <div className={cn("flex gap-x-2 items-center relative")}>
-        <div className={cn("flex justify-end gap-x-2 w-[208px]")}>
+      <div className={cn("flex items-center relative")}>
+        <div className={cn("flex justify-center gap-x-2 w-[208px]")}>
           {preview.map((reaction) => {
             return <BadgeEmoji key={reaction.id} reactions={reaction} />;
           })}
         </div>
         {count > 3 && (
-          <div className={cn("flex items-center")} onClick={onClickOpen}>
+          <div
+            className={cn("flex items-center w-[36px]")}
+            onClick={onClickOpen}
+          >
             <Icon
               iconName="arrow_down"
               iconSize="ic-24"
@@ -49,7 +52,8 @@ const DropdownEmoji = ({ reactionData }) => {
           <div className={cn("absolute top-12 right-px")}>
             <div
               className={cn(
-                "w-[312px] h-[134px] p-[24px] bg-white",
+                "tablet:w-[312px] tablet:h-[134px] p-[24px] bg-white",
+                "mobile:w-[248px] h-[134px]",
                 "border border-gray-dropdownBorder rounded-lg",
                 "drop-shadow-dropdownBorder"
               )}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,7 @@ export default {
           900: "#181818",
           headerLogo: "#4A494F",
           headerBorder: "#EDEDED",
+          dropdownBorder: "#B6B6B6",
         },
         purple: {
           100: "#F8F0FF",
@@ -77,6 +78,9 @@ export default {
         "gray-300": "inset 0 0 0 1px #CCCCCC",
         "gray-500": "inset 0 0 0 1px #555555",
         "gray-800": "inset 0 0 0 1px #2B2B2B",
+      },
+      dropShadow: {
+        dropdownBorder: "0 2px 12px rgba(0, 0, 0, 0.08)",
       },
       fontFamily: {
         poppins: ["Poppins"],


### PR DESCRIPTION
## 변경 사항 요약
API로 받은 리액션 정보에 담긴 이모지를 드롭다운을 통해 펼쳐볼 수 있습니다

### 추가된 기능

- [ ] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [ ] UI 변경
- [ ] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항
- 드롭다운을 펼치지 않았을 때 기본적으로 최대 3개의 이모지가 표출이 되며 이는 개수에 맞춰 줄어듭니다.
- 컴포넌트에 `dropdown={false}` prop으로 아이콘을 비활성화하거나 리액션이 3개 이하일 경우 아이콘이 비활성화 됩니다.
<img width="245" height="41" alt="스크린샷 2025-08-13 13 15 46" src="https://github.com/user-attachments/assets/d422c22e-e918-4023-90fa-606541f9095d" />
<img width="334" height="196" alt="스크린샷 2025-08-13 13 15 54" src="https://github.com/user-attachments/assets/106668a6-6612-499c-b555-192432c82413" />

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인
