### PR TITLE
Skeleton UI 홀수 개수 고려하여 속성 변경 및 예시주석 추가

### DIFF
--- a/src/components/Skeleton/SkeletonElements/SkeletonBox.jsx
+++ b/src/components/Skeleton/SkeletonElements/SkeletonBox.jsx
@@ -16,7 +16,7 @@ const SkeletonBox = ({ className = "" }) => {
   return (
     <div
       className={cn(
-        "w-[100%] flex-0 aspect-square rounded-2xl",
+        "w-full flex-0 aspect-square rounded-2xl",
         "bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200",
         "bg-[length:400%_100%]",
         "animate-skeleton-shimmer",

--- a/src/components/Skeleton/SkeletonElements/SkeletonBox.jsx
+++ b/src/components/Skeleton/SkeletonElements/SkeletonBox.jsx
@@ -16,7 +16,7 @@ const SkeletonBox = ({ className = "" }) => {
   return (
     <div
       className={cn(
-        "w-[calc(50%-1rem)] flex-auto aspect-square rounded-2xl",
+        "w-[calc(50%-1rem)] flex-0 aspect-square rounded-2xl",
         "bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200",
         "bg-[length:400%_100%]",
         "animate-skeleton-shimmer",

--- a/src/components/Skeleton/SkeletonElements/SkeletonBox.jsx
+++ b/src/components/Skeleton/SkeletonElements/SkeletonBox.jsx
@@ -16,7 +16,7 @@ const SkeletonBox = ({ className = "" }) => {
   return (
     <div
       className={cn(
-        "w-[calc(50%-1rem)] flex-0 aspect-square rounded-2xl",
+        "w-[100%] flex-0 aspect-square rounded-2xl",
         "bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200",
         "bg-[length:400%_100%]",
         "animate-skeleton-shimmer",

--- a/src/components/Skeleton/SkeletonUI.jsx
+++ b/src/components/Skeleton/SkeletonUI.jsx
@@ -13,10 +13,10 @@ import SkeletonBox from "./SkeletonElements/SkeletonBox";
  *
  * @example
  * <SkeletonUI count={3} />
- * <SkeletonUI count="5" boxClassName="w-[100%] sm:w-[calc((100%-1rem)/2)] tablet:w-[calc((100%-(1rem*2))/3)]" ></SkeletonUI> 
+ * <SkeletonUI count="5" boxClassName="sm:w-[calc((100%-1rem)/2)] tablet:w-[calc((100%-(1rem*2))/3)]" ></SkeletonUI> 
  * 
  * 반응형 작성시 개인 페이지에 맞개 수정이 필요합니다! 
- * 모든 페이지가 4칸/3칸/2칸/1칸 다 다르기때문에 모바일 기준 2칸으로만 작성되었습니다. 
+ * 모든 페이지가 4칸/3칸/2칸/1칸 다 다르기때문에 모바일 기준 w-full로 작성되었습니다. 
  * example 코드를 참고해서 적용 부탁드립니다.
  */
 const SkeletonUI = ({ count, className = "", boxClassName = "" }) => {

--- a/src/components/Skeleton/SkeletonUI.jsx
+++ b/src/components/Skeleton/SkeletonUI.jsx
@@ -13,15 +13,15 @@ import SkeletonBox from "./SkeletonElements/SkeletonBox";
  *
  * @example
  * <SkeletonUI count={3} />
+ * <SkeletonUI count="5" boxClassName="w-[100%] sm:w-[calc((100%-1rem)/2)] tablet:w-[calc((100%-(1rem*2))/3)]" ></SkeletonUI> 
+ * 
+ * 반응형 작성시 개인 페이지에 맞개 수정이 필요합니다! 
+ * 모든 페이지가 4칸/3칸/2칸/1칸 다 다르기때문에 모바일 기준 2칸으로만 작성되었습니다. 
+ * example 코드를 참고해서 적용 부탁드립니다.
  */
 const SkeletonUI = ({ count, className = "", boxClassName = "" }) => {
   return (
-    <div
-      className={cn(
-        "flex flex-row flex-wrap justify-between gap-4 w-full",
-        className
-      )}
-    >
+    <div className={cn("flex flex-row flex-wrap gap-4 w-full", className)}>
       {Array.from({ length: count }).map((_, i) => (
         <SkeletonBox key={i} className={boxClassName} />
       ))}

--- a/src/features/Option/OptionElements/OptionImage.jsx
+++ b/src/features/Option/OptionElements/OptionImage.jsx
@@ -34,7 +34,7 @@ const OptionImage = ({ bgImages, onImageSelect, isLoading }) => {
       {showSkeleton && (
         <SkeletonUI
           count={imageUrlCount}
-          className="tablet:flex-nowrap absolute z-20"
+          className="w-[calc(50%-1rem)] tablet:flex-nowrap absolute z-20"
         />
       )}
       {bgImages.imageUrls.map((image, index) => (


### PR DESCRIPTION
## 변경 사항 요약

스켈레톤 ui css 변경 

### 추가된 기능

- [ ] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [x] UI 변경
- [ ] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항

페이지 및 반응형 마다 4칸, 3칸, 2칸, 1칸 등 피그마에 작성된 갯수가 각기 달라
모바일 퍼스트로 w-full로 css를 변경했습니다.

`<SkeletonUI count="5" boxClassName="sm:w-[calc((100%-1rem)/2)] tablet:w-[calc((100%-(1rem*2))/3)]" ></SkeletonUI> `

예시 주석을 작성해 놓았습니다. 원하는 스타일에 맞추어 너비를 지정해주시면 됩니다 :) 
만약 줄바꿈을 원하지 않으시다면 flex-nowrap 클래스를 넣어주시면 됩니다!

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인
