### PR TITLE
toast 컴포넌트 수정

### DIFF
--- a/src/components/Toast/Toast.jsx
+++ b/src/components/Toast/Toast.jsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import icCompleted from "../../assets/icon/ic_completed.svg";
 import icClosed from "../../assets/icon/ic_close.svg";
 import { cn } from "../../utils";
+import { createPortal } from "react-dom";
 
 const Toast = ({
   isOpen,
@@ -18,11 +19,11 @@ const Toast = ({
 
   if (!isOpen) return null;
 
-  return (
+  const toastNode = (
     <div
       className={cn(
         "fixed bg-black/80 text-16 text-white left-1/2 -translate-x-1/2",
-        "flex items-center justify-between",
+        "flex items-center justify-between z-50",
         "px-[30px] py-[19px] rounded-lg",
         "w-[70vw] bottom-[88px]",
         "tablet:w-[524px] tablet:bottom-[50px]",
@@ -38,6 +39,8 @@ const Toast = ({
       </button>
     </div>
   );
+
+  return createPortal(toastNode, document.body);
 };
 
 export default Toast;

--- a/src/components/Toast/Toast.jsx
+++ b/src/components/Toast/Toast.jsx
@@ -31,7 +31,7 @@ const Toast = ({
       )}
     >
       <div className="flex items-center gap-[12px]">
-        <img src={icCompleted} alt="완료 아이콘" />
+        <img src={icCompleted} alt="상태 아이콘" />
         <span className="text-[14px]">{message}</span>
       </div>
       <button onClick={onClose} className="flex items-center">


### PR DESCRIPTION
## 변경 사항 요약

toast 컴포넌트 다른 컴포넌트 뒤로 가려지는 문제 수정
토스트 체크 이미지 ic_completed 의  alt 속성  "완료 아이콘 -> 상태 아이콘 " 으로 변경

### 추가된 기능

- [ ] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [x] 리팩토링 (기능 변경 없이 코드 개선)
- [ ] UI 변경
- [x] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항

Toast를 document.body 에 Portal로 렌더링하도록 변경
z index 50으로 변경

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인


<img width="785" height="382" alt="image" src="https://github.com/user-attachments/assets/b2f26d99-8c0f-4c29-af90-c8dc88074fae" />
