### PR TITLE
NotFound 페이지에 Footer 제작

### DIFF
--- a/src/components/NotFound/NotFoundFooter.jsx
+++ b/src/components/NotFound/NotFoundFooter.jsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { cn } from "../../utils";
 import useRecipientsCount from "./hooks/useGetRecipientsCount";
 

--- a/src/components/NotFound/NotFoundFooter.jsx
+++ b/src/components/NotFound/NotFoundFooter.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { cn } from "../../utils";
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+const NotFoundFooter = () => {
+  const [count, setCount] = useState(null);
+
+  useEffect(() => {
+    const fetchTotalRecipients = async () => {
+      try {
+        const res = await fetch(`${BASE_URL}/18-4/recipients/`);
+        const data = await res.json();
+        setCount(data.count);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchTotalRecipients();
+  }, []);
+
+  if (count === null) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3",
+        "rounded-2xl px-5 py-3 w-[min(80vw,720px)]",
+        "bg-purple-500 text-white mx-auto"
+      )}
+    >
+      <span
+        className="
+            inline-flex items-center justify-center
+            w-10 h-10 rounded-full bg-purple-400
+            text-20 font-bold
+          "
+      >
+        {count}
+      </span>
+      <span className="text-20 font-bold">명이 메세지를 기다리고 있어요</span>
+    </div>
+  );
+};
+
+export default NotFoundFooter;

--- a/src/components/NotFound/NotFoundFooter.jsx
+++ b/src/components/NotFound/NotFoundFooter.jsx
@@ -25,7 +25,7 @@ const NotFoundFooter = () => {
   return (
     <div
       className={cn(
-        "flex items-center gap-3",
+        "flex items-center gap-3 justify-center",
         "rounded-2xl px-5 py-3 w-[min(80vw,720px)]",
         "bg-purple-500 text-white mx-auto"
       )}

--- a/src/components/NotFound/NotFoundFooter.jsx
+++ b/src/components/NotFound/NotFoundFooter.jsx
@@ -1,24 +1,11 @@
 import { useEffect, useState } from "react";
 import { cn } from "../../utils";
+import useRecipientsCount from "./hooks/useGetRecipientsCount";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 const NotFoundFooter = () => {
-  const [count, setCount] = useState(null);
-
-  useEffect(() => {
-    const fetchTotalRecipients = async () => {
-      try {
-        const res = await fetch(`${BASE_URL}/18-4/recipients/`);
-        const data = await res.json();
-        setCount(data.count);
-      } catch (err) {
-        console.error(err);
-      }
-    };
-
-    fetchTotalRecipients();
-  }, []);
+  const count = useRecipientsCount();
 
   if (count === null) return null;
 
@@ -27,19 +14,21 @@ const NotFoundFooter = () => {
       className={cn(
         "flex items-center gap-3 justify-center",
         "rounded-2xl px-5 py-3 w-[min(80vw,720px)]",
-        "bg-purple-500 text-white mx-auto"
+        "bg-purple-500 mx-auto"
       )}
     >
       <span
-        className="
-            inline-flex items-center justify-center
-            w-10 h-10 rounded-full bg-purple-400
-            text-20 font-bold
-          "
+        className={cn(
+          "inline-flex items-center justify-center",
+          "w-10 h-10 rounded-full bg-purple-400",
+          "text-20 text-white font-bold"
+        )}
       >
         {count}
       </span>
-      <span className="text-20 font-bold">명이 메세지를 기다리고 있어요</span>
+      <span className="text-white text-20 font-bold">
+        명이 메세지를 기다리고 있어요
+      </span>
     </div>
   );
 };

--- a/src/components/NotFound/hooks/useGetRecipientsCount.jsx
+++ b/src/components/NotFound/hooks/useGetRecipientsCount.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+const useRecipientsCount = () => {
+  const [count, setCount] = useState(null);
+
+  useEffect(() => {
+    const fetchTotalRecipients = async () => {
+      try {
+        const res = await fetch(`${BASE_URL}/18-4/recipients/`);
+        if (!res.ok) throw new Error("Failed to fetch recipients count");
+        const data = await res.json();
+        setCount(data.count);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchTotalRecipients();
+  }, []);
+
+  return count;
+};
+
+export default useRecipientsCount;

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,53 +3,57 @@ import Paper from "../assets/img/img_not_found_paper.png";
 import { cn } from "../utils";
 import Img404 from "../assets/img/img_not_found_404.png";
 import NotFoundButtons from "../components/NotFound/NotFoundButtons";
+import NotFoundFooter from "../components/NotFound/NotFoundFooter";
 
 function NotFound() {
   return (
-    <div
-      className="
-        relative min-h-screen
-        flex items-center justify-center
-      "
-    >
+    <div className={cn("relative min-h-screen flex-col", "flex")}>
       <img
         src={BackGround}
         alt="배경 이미지"
         className={cn("absolute -z-20 w-full h-full object-cover")}
       />
 
-      <img
-        src={Paper}
-        alt="종이 이미지"
-        className={cn(
-          "-z-10",
-          " min-w-[440px]",
-          "tablet:w-[98vw] max-w-[750px]",
-          "desktop:w-[98vw] max-w-[750px]"
-        )}
-      />
-
-      <div className={cn("absolute items-center justify-center text-center")}>
+      {/* 본문 */}
+      <div className="flex-1 flex items-center justify-center">
         <img
-          src={Img404}
-          alt="404 이미지"
+          src={Paper}
+          alt="종이 이미지"
           className={cn(
-            "mx-auto block",
-            "w-[clamp(300px,40vw,500px)]",
-            "tablet:w-[500px]",
-            "desktop:w-[500px]"
+            "-z-10",
+            " min-w-[440px]",
+            "tablet:w-[98vw] max-w-[750px]",
+            "desktop:w-[98vw] max-w-[750px]"
           )}
         />
-        <div
-          className={cn(
-            "text-[clamp(20px,5vw,30px)] -mt-6 font-bold text-purple-400 py-2",
-            "tablet:text-[30px] tablet:-mt-20 tablet:py-6",
-            "desktop:text-[30px] desktop:-mt-20 desktop:py-6"
-          )}
-        >
-          페이지를 찾을 수 없어요
+
+        <div className={cn("absolute items-center justify-center text-center")}>
+          <img
+            src={Img404}
+            alt="404 이미지"
+            className={cn(
+              "mx-auto block",
+              "w-[clamp(300px,40vw,500px)]",
+              "tablet:w-[500px]",
+              "desktop:w-[500px]"
+            )}
+          />
+          <div
+            className={cn(
+              "text-[clamp(20px,5vw,30px)] -mt-6 font-bold text-purple-400 py-2",
+              "tablet:text-[30px] tablet:-mt-20 tablet:py-6",
+              "desktop:text-[30px] desktop:-mt-20 desktop:py-6"
+            )}
+          >
+            페이지를 찾을 수 없어요
+          </div>
+          <NotFoundButtons />
         </div>
-        <NotFoundButtons />
+      </div>
+
+      {/* 푸터 */}
+      <div className="mt-auto mb-48">
+        <NotFoundFooter />
       </div>
     </div>
   );

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,12 +1,10 @@
 import BackGround from "../assets/img/img_not_found_background.png";
 import Paper from "../assets/img/img_not_found_paper.png";
-import { useNavigate } from "react-router";
 import { cn } from "../utils";
 import Img404 from "../assets/img/img_not_found_404.png";
 import NotFoundButtons from "../components/NotFound/NotFoundButtons";
 
 function NotFound() {
-  const navigate = useNavigate();
   return (
     <div
       className="

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -7,14 +7,13 @@ import NotFoundFooter from "../components/NotFound/NotFoundFooter";
 
 function NotFound() {
   return (
-    <div className={cn("relative min-h-screen flex-col", "flex")}>
+    <div className={cn("relative min-h-screen flex-col flex")}>
       <img
         src={BackGround}
         alt="배경 이미지"
         className={cn("absolute -z-20 w-full h-full object-cover")}
       />
 
-      {/* 본문 */}
       <div className="flex-1 flex items-center justify-center">
         <img
           src={Paper}
@@ -50,8 +49,6 @@ function NotFound() {
           <NotFoundButtons />
         </div>
       </div>
-
-      {/* 푸터 */}
       <div className="mt-auto mb-48">
         <NotFoundFooter />
       </div>


### PR DESCRIPTION
## 변경 사항 요약

NotFound 페이지 하단에 현재 올라온 롤링페이퍼(메세지를 기다리는)수 보여주는 Footer 제작

### 추가된 기능

- [ ] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [ ] UI 변경
- [ ] 성능 개선
- [x] 기타 (설명해주세요): NotFound 페이지 하단에 현재 올라온 롤링페이퍼(메세지를 기다리는)수 보여주는 Footer 제작

### 리뷰어를 위한 참고 사항

다른 페이지에는 지금 넣기 애매해서 독립적인 페이지인 NotFound 페이지에만 만들었습니다.
만들다보니 Footer 보다는 배너 같은 느낌이 되어버렸습니다.

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인


mobile
<img width="637" height="1015" alt="mobile" src="https://github.com/user-attachments/assets/3385a325-89bd-401e-8ea2-2cd8a9376b75" />


table, desktop
<img width="1166" height="1113" alt="desktop" src="https://github.com/user-attachments/assets/d046ac7f-742c-4d40-890d-e8fdc7067550" />
