### PR TITLE
Modal의 width를 DeleteModal 의 width와 같게 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "rolling",
       "version": "0.0.0",
       "dependencies": {
-        "@tanstack/react-query": "^5.85.4",
-        "@tanstack/react-query-devtools": "^5.85.4",
         "@cloudinary/react": "^1.14.3",
         "@cloudinary/url-gen": "^1.21.0",
+        "@tanstack/react-query": "^5.85.4",
+        "@tanstack/react-query-devtools": "^5.85.4",
         "autoprefixer": "^10.4.21",
         "clsx": "^2.1.1",
         "emoji-picker-react": "^4.13.2",

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -33,7 +33,7 @@ const Modal = ({
         className={cn(
           "rounded-[20px] bg-white shadow-lg border border-gray-200 p-6",
           "flex flex-col overflow-hidden",
-          "w-[70vw] h-[40vh] min-h-[300px]",
+          "w-[90vw] max-w-[600px] h-[40vh] min-h-[300px]",
           "tablet:w-[600px] tablet:h-[476px]",
           "desktop:w-[600px] desktop:h-[476px]"
         )}


### PR DESCRIPTION
## 변경 사항 요약

Modal의 width를 DeleteModal 의 width와 같게 수정

### 추가된 기능

- [ ] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [x] UI 변경
- [ ] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항

Modal.jsx의 width 관련 class만 수정하였습니다. ( DeleteModal.jsx 와 똑같이 )

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인

<img width="627" height="1136" alt="modal1" src="https://github.com/user-attachments/assets/b11abf6d-b77c-433b-849d-9f704b4702c2" />
<img width="627" height="1132" alt="modal2" src="https://github.com/user-attachments/assets/173d7fa8-f674-480e-ac81-2aeb90162102" />

